### PR TITLE
chore: avoid use of deprecated disable_bgp_route_propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ module "azure_network_route_table" {
   #custom_name = "my_route_table"
 
   # Options
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = false
 
   enable_force_tunneling = true
 
@@ -141,10 +141,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| bgp\_route\_propagation\_enabled | Option to disable BGP route propagation on this Route Table. | `bool` | `false` | no |
 | client\_name | Client name/account used in naming | `string` | n/a | yes |
 | custom\_name | Custom Route table name, generated if not set | `string` | `""` | no |
 | default\_tags\_enabled | Option to enable or disable default tags | `bool` | `true` | no |
-| disable\_bgp\_route\_propagation | Option to disable BGP route propagation on this Route Table. | `bool` | `false` | no |
 | enable\_force\_tunneling | Option to enable a route to Force Tunneling (force 0.0.0.0/0 traffic through the Gateway next hop). | `bool` | `false` | no |
 | environment | Project environment | `string` | n/a | yes |
 | extra\_tags | Additional tags to associate with your resources. | `map(string)` | `{}` | no |

--- a/examples/main/modules.tf
+++ b/examples/main/modules.tf
@@ -44,7 +44,7 @@ module "azure_network_route_table" {
   #custom_name = "my_route_table"
 
   # Options
-  disable_bgp_route_propagation = false
+  bgp_route_propagation_enabled = false
 
   enable_force_tunneling = true
 

--- a/r-route-table.tf
+++ b/r-route-table.tf
@@ -3,7 +3,7 @@ resource "azurerm_route_table" "route_table" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  disable_bgp_route_propagation = var.disable_bgp_route_propagation
+  bgp_route_propagation_enabled = var.disable_bgp_route_propagation
 
   tags = merge(local.default_tags, var.extra_tags)
 }

--- a/r-route-table.tf
+++ b/r-route-table.tf
@@ -3,7 +3,7 @@ resource "azurerm_route_table" "route_table" {
   location            = var.location
   resource_group_name = var.resource_group_name
 
-  bgp_route_propagation_enabled = var.disable_bgp_route_propagation
+  bgp_route_propagation_enabled = var.bgp_route_propagation_enabled
 
   tags = merge(local.default_tags, var.extra_tags)
 }
@@ -17,4 +17,3 @@ resource "azurerm_route" "force_internet_tunneling" {
 
   count = var.enable_force_tunneling ? 1 : 0
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "resource_group_name" {
   type        = string
 }
 
-variable "disable_bgp_route_propagation" {
+variable "bgp_route_propagation_enabled" {
   description = "Option to disable BGP route propagation on this Route Table."
   type        = bool
   default     = false


### PR DESCRIPTION
Ports fix for #2

The variable name has not changed, so this is not a breaking change.

